### PR TITLE
Allow using an alternate python path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Autocomplete Jedi Package
 
-View and insert possible Python completions in the editor using `Ctrl-Alt-Space`.
+View and insert possible Python completions in the editor using
+`Ctrl-Alt-Space`.
 You must have the Python module 'jedi' installed:
 
     (sudo) pip install jedi
+
+If you have multiple python installations (e.g. python2 and python3), you can
+select which python has jedi installed in the settings.
+
+**NB:** Atom has a known bug where settings sometimes won't appear until after a
+package has been activated at least once. If you don't see a place to specify
+the path to your prefered python executable in the settings, try to trigger
+autocomplete-jedi and then check again.
 
 #### *Very basic functionality at the moment*

--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -86,9 +86,11 @@ class AutocompleteView extends SelectListView
     # get our autocomplete shit here
     point = @editor.getCursorScreenPosition()
     pyfile = @editor.getBuffer().getPath()
-    console.log('Inspecing: ' + pyfile)
+    console.log('Inspecting: ' + pyfile)
     args = [path.resolve(__dirname, 'completions.py'), @editor.getText(), point.row + 1, point.column, pyfile]
-    @jediProc = process.spawn('python', args)
+   
+    whichPython = atom.config.get('autocomplete-jedi.whichPython')
+    @jediProc = process.spawn(whichPython, args)
 
     @dataOut = ""
     me = @

--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -2,8 +2,13 @@ _ = require 'underscore-plus'
 AutocompleteView = require './autocomplete-view'
 
 module.exports =
-  configDefaults:
-    includeCompletionsFromAllBuffers: false
+  config:
+    includeCompletionsFromAllBuffers: 
+      type: 'boolean'
+      default: false
+    whichPython:
+      type: 'string'
+      default: 'python'
 
   autocompleteViews: []
   editorSubscription: null

--- a/lib/completions.py
+++ b/lib/completions.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import jedi
 import sys
 


### PR DESCRIPTION
I have jedi installed under python3 on OSX and hardly use python2, so I gave the package a config setting to allow an alternate python path. Still defaults to `python`, same as before, so shouldn't break any existing functionality.
