### PR TITLE
Update autocomplete.cson - Fix deprecation warning

### DIFF
--- a/keymaps/autocomplete.cson
+++ b/keymaps/autocomplete.cson
@@ -1,6 +1,6 @@
-'.editor':
+'atom-text-editor':
   'ctrl-alt-space': 'autocomplete-jedi:toggle'
 
-'.autocomplete-jedi .mini.editor input':
+'.autocomplete-jedi atom-text-editor[mini] input':
   'enter': 'core:confirm'
   'tab': 'core:confirm'


### PR DESCRIPTION
Fix atom deprecation warning about the use of .editor class and .mini.editor